### PR TITLE
Remove body+3 from mage's staff

### DIFF
--- a/login.cpp
+++ b/login.cpp
@@ -2226,10 +2226,10 @@ void UpdateCharacter(CCharacter& chr, int srvid, unsigned int* ascended, unsigne
             chr.Picture = 32;
             std::string serializedDress = "[0,0,40,12];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[18118,1,2,1,{2:3:0:0},{19:2:0:0}];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1]";
             chr.Dress = Login_UnserializeItems(serializedDress);
-        } else if (chr.Sex == 192) { // witch become mage and get STAFF +3 (Good Bone Staff) body
+        } else if (chr.Sex == 192) { // witch become mage and get physical damage staff
             chr.Sex = 64;
             chr.Picture = 15;
-            std::string serializedDress = "[0,0,40,12];[53709,1,2,1,{2:3:0:0}];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1]";
+            std::string serializedDress = "[0,0,40,12];[53709,0,2,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1];[0,0,0,1]";
             chr.Dress = Login_UnserializeItems(serializedDress);
         }
     } else {


### PR DESCRIPTION
This makes the staff just pure physical damage.

I didn't test this, but I think it works. The order of fields in the serialization is: [item ID, is magic, price, count, {optional magic}].