### PR TITLE
Add item merging logic when saving the character

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(redhat-lib
     lgn.cpp
     listener.cpp
     login.cpp
+    merge_items.cpp
     packet.cpp
     serialize.cpp
     server.cpp
@@ -42,6 +43,7 @@ target_link_libraries(redhat redhat-lib)
 
 add_executable(redhat-test
     test/login_test.cpp
+    test/merge_items_test.cpp
     test/test.cpp
     test/UnitTest++/AssertException.cpp
     test/UnitTest++/AssertException.h
@@ -118,6 +120,13 @@ target_compile_options(redhat-test PUBLIC /MT)
 target_link_options(redhat-test PUBLIC /NODEFAULTLIB:MSVCRT)
 
 # Run the test.
+add_custom_command(
+    TARGET redhat-test
+    POST_BUILD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND copy mysql\\lib\\libmysql.dll ${RUNTIME_OUTPUT_DIRECTORY}/libmysql.dll
+)
+
 add_custom_command(
     TARGET redhat-test
     POST_BUILD

--- a/login.cpp
+++ b/login.cpp
@@ -2,6 +2,7 @@
 #include "sql.hpp"
 #include "utils.hpp"
 #include "config.hpp"
+#include "merge_items.hpp"
 
 #include "sha1.h"
 
@@ -1833,6 +1834,8 @@ void UpdateCharacter(CCharacter& chr, int srvid, unsigned int* ascended, unsigne
             chr.Picture = 64; // zombie
         }
     }
+
+    MergeItems(chr.Bag);
 
     ////////////
     // REBORN //

--- a/merge_items.cpp
+++ b/merge_items.cpp
@@ -5,6 +5,10 @@
 void Improve(CItem& item);
 
 void MergeItems(CItemList& bag) {
+    if (bag.Items.size() < MERGE_COUNT) {
+        return;
+    }
+
     for (auto it = bag.Items.begin(); it < bag.Items.end() - (MERGE_COUNT-1); ++it) {
         if (it->Price != 2) {
             continue;

--- a/test/merge_items_test.cpp
+++ b/test/merge_items_test.cpp
@@ -8,6 +8,14 @@
 namespace
 {
 
+TEST(MergeItems_EmptyBag) {
+    CItemList items = Login_UnserializeItems("[0,0,0,0]");
+    MergeItems(items);
+    std::string got = Login_SerializeItems(items);
+
+    CHECK_EQUAL("[0,0,0,0]", got);
+}
+
 TEST(MergeItems_NoChanges) {
     CItemList items = Login_UnserializeItems("[0,0,0,2];[3667,0,0,1];[1000,0,2,1]");
     MergeItems(items);


### PR DESCRIPTION
If a player has three items of the same type sequentially in their inventory, they will be merged into one buffed item. Currently the only buff is increasing max health by 5, but we can add more later.

I'm fixing CMake build on the way, the main change is in `login.cpp`.