### PR TITLE
Change treasures on nightmare+ maps:

### DIFF
--- a/login.cpp
+++ b/login.cpp
@@ -2282,58 +2282,37 @@ void UpdateCharacter(CCharacter& chr, ServerIDType srvid, shelf::StoreOnShelfFun
                 *points += 15;
                 break;
             case NIGHTMARE: // 2 treasures per map
-                if (coinflip) {
-                    ; // treasure at 7 server works in 50% cases
-                } else {
-                    if (chr.Sex == 192) { // witch increases Body at 7 a bit faster as starts from 1
-                        if (chr.Body < 15) {
-                            chr.Body += 5;
-                        } else if (chr.Body < 25) {
-                            chr.Body += 4;
-                        } else if (chr.Body < 35) {
-                            chr.Body += 3;
-                        } else if (chr.Body < 45) {
-                            chr.Body += 2;
-                        } else {
-                            chr.Body++;
-                        }
-                    } else if (chr.Sex == 128) { // amazon
-                        if (chr.Body < 35) {
-                            chr.Body += 3;
-                        } else if (chr.Body < 45) {
-                            chr.Body += 2;
-                        } else {
-                            chr.Body++;
-                        }
-                    } else { // warrior and mage
-                        chr.Body++;
-                    }
-                }
+                // treasure at 7 server works in 50% cases
+                update_character::TreasureOnNightmare(chr, coinflip);
                 *points += 15;
                 break;
             case QUEST_T1: // 1 treasure. 2x-3x more mind
                 if (coinflip) {
-                    chr.Mind += 3;
+                    update_character::IncreaseUpTo(&chr.Mind, 3, 70);
                 } else {
-                    chr.Mind += 2;
+                    update_character::IncreaseUpTo(&chr.Mind, 2, 70);
                 }
                 *points += 30;
                 break;
             case QUEST_T2: // at 9, 10 - we have 3 treasures per map
-                chr.Spirit++;
+                update_character::IncreaseUpTo(&chr.Spirit, 1, 70);
+                if (i == 0 && haveTreasures == 3) { // A bonus for getting all three treasures.
+                    update_character::IncreaseUpTo(&chr.Spirit, 1, 70);
+                }
                 *points = 100;
                 break;
             case QUEST_T3:
-                chr.Reaction++;
+                update_character::IncreaseUpTo(&chr.Reaction, 1, 70);
+                if (i == 0 && haveTreasures == 3) { // A bonus for getting all three treasures.
+                    update_character::IncreaseUpTo(&chr.Reaction, 1, 70);
+                }
                 *points += 100;
                 break;
             case QUEST_T4: // 1 treasure
-                if (chr.Spirit < 76) {
-                    chr.Spirit += 2;
-                } else if (chr.Mind < 76) {
-                    chr.Mind += 2;
-                } else {
-                    chr.Reaction += 2;
+                for (int j = 0; j < 2; ++j) {
+                    update_character::IncreaseUpTo(&chr.Mind, 1, 76)
+                        || update_character::IncreaseUpTo(&chr.Spirit, 1, 76) 
+                        || update_character::IncreaseUpTo(&chr.Reaction, 1, 76);
                 }
                 *points += 500;
                 break;

--- a/test/login_test.cpp
+++ b/test/login_test.cpp
@@ -595,7 +595,7 @@ TEST(UpdateCharacter_Ascend_Amazon_Success) {
     CHECK_CHARACTER(chr, want);
 }
 
-TEST(UpdateCharacter_NoChanges_7) {
+TEST(UpdateCharacter_NoChanges_Nightmare) {
     CCharacter chr = FakeCharacter(
         CharacterOpts{
             .info={.main_skill=1, .sex=64, .deaths=10, .kills=4200},
@@ -623,7 +623,7 @@ TEST(UpdateCharacter_NoChanges_7) {
     CHECK_CHARACTER(chr, want);
 }
 
-TEST(UpdateCharacter_TreasureOn7) {
+TEST(UpdateCharacter_TreasureOnNightmare) {
     CCharacter chr = FakeCharacter(
         CharacterOpts{
             .stats={.body=50, .reaction=50, .mind=50, .spirit=50},
@@ -649,7 +649,7 @@ TEST(UpdateCharacter_TreasureOn7) {
     CHECK_CHARACTER(chr, want);
 }
 
-TEST(UpdateCharacter_TreasureOn8) {
+TEST(UpdateCharacter_TreasureOnQuestT1) {
     CCharacter chr = FakeCharacter(
         CharacterOpts{
             .stats={.body=50, .reaction=50, .mind=50, .spirit=50},
@@ -670,6 +670,116 @@ TEST(UpdateCharacter_TreasureOn8) {
             .stats={.body=50, .reaction=50, .mind=55, .spirit=50}, // Mind is increased, 2+3.
             .skills={.astral=1000},
             .items={.money=5000000, .bag="[0,0,0,2];[1000,0,0,1];[2000,0,0,2]"},
+        }
+    );
+    CHECK_CHARACTER(chr, want);
+}
+
+TEST(UpdateCharacter_TreasureLimitOnQuestT1) {
+    CCharacter chr = FakeCharacter(
+        CharacterOpts{
+            .stats={.body=50, .reaction=50, .mind=69, .spirit=50},
+            .skills={.astral=1000},
+            .items={.bag="[0,0,0,1];[3667,0,0,1]"},
+        }
+    );
+
+    unsigned int ascended = 0;
+    unsigned int points = 0;
+    UpdateCharacter(chr, QUEST_T1, FakeStoreOnShelf, &ascended, &points);
+
+    CCharacter want = FakeCharacter(
+        CharacterOpts{
+            .stats={.body=50, .reaction=50, .mind=70, .spirit=50}, // Mind is increased up to 70.
+            .skills={.astral=1000},
+            .items={.money=5000000, .bag="[0,0,0,0]"},
+        }
+    );
+    CHECK_CHARACTER(chr, want);
+}
+
+TEST(UpdateCharacter_TreasureBonusOnQuestT2) {
+    CCharacter chr = FakeCharacter(
+        CharacterOpts{
+            .stats={.body=50, .reaction=50, .mind=50, .spirit=50},
+            .skills={.astral=1000},
+            .items={.bag="[0,0,0,1];[3667,0,0,3]"},
+        }
+    );
+
+    unsigned int ascended = 0;
+    unsigned int points = 0;
+    UpdateCharacter(chr, QUEST_T2, FakeStoreOnShelf, &ascended, &points);
+
+    CCharacter want = FakeCharacter(
+        CharacterOpts{
+            .stats={.body=50, .reaction=50, .mind=50, .spirit=54}, // Spirit += 3 + 1
+            .skills={.astral=1000},
+            .items={.money=7000000, .bag="[0,0,0,0]"},
+        }
+    );
+    CHECK_CHARACTER(chr, want);
+}
+
+TEST(UpdateCharacter_TreasureOnQuestT4) {
+    CCharacter chr = FakeCharacter(
+        CharacterOpts{
+            .stats={.body=50, .reaction=72, .mind=73, .spirit=74},
+            .skills={.astral=1000},
+            .items={.money=2147483647, .bag="[0,0,0,1];[3667,0,0,1]"},
+        }
+    );
+
+    unsigned int ascended = 0;
+    unsigned int points = 0;
+
+    // First, mind is increased.
+    UpdateCharacter(chr, QUEST_T4, FakeStoreOnShelf, &ascended, &points);
+
+    CCharacter want = FakeCharacter(
+        CharacterOpts{
+            .stats={.body=50, .reaction=72, .mind=75, .spirit=74},
+            .skills={.astral=1000},
+            .items={.money=2147483647, .bag="[0,0,0,0]"},
+        }
+    );
+    CHECK_CHARACTER(chr, want);
+
+    // Mind is increased by 1 to the limit of 76, one point goes to spirit.
+    chr.Bag.Items.push_back(CItem{.Id=3667, .Count=1});
+    UpdateCharacter(chr, QUEST_T4, FakeStoreOnShelf, &ascended, &points);
+
+    want = FakeCharacter(
+        CharacterOpts{
+            .stats={.body=50, .reaction=72, .mind=76, .spirit=75},
+            .skills={.astral=1000},
+            .items={.money=2147483647, .bag="[0,0,0,0]"},
+        }
+    );
+    CHECK_CHARACTER(chr, want);
+
+    // Spirit is increased by 1 to the limit of 76, one point goes to reaction.
+    chr.Bag.Items.push_back(CItem{.Id=3667, .Count=1});
+    UpdateCharacter(chr, QUEST_T4, FakeStoreOnShelf, &ascended, &points);
+
+    want = FakeCharacter(
+        CharacterOpts{
+            .stats={.body=50, .reaction=73, .mind=76, .spirit=76},
+            .skills={.astral=1000},
+            .items={.money=2147483647, .bag="[0,0,0,0]"},
+        }
+    );
+    CHECK_CHARACTER(chr, want);
+
+    // Two points to reaction.
+    chr.Bag.Items.push_back(CItem{.Id=3667, .Count=1});
+    UpdateCharacter(chr, QUEST_T4, FakeStoreOnShelf, &ascended, &points);
+
+    want = FakeCharacter(
+        CharacterOpts{
+            .stats={.body=50, .reaction=75, .mind=76, .spirit=76},
+            .skills={.astral=1000},
+            .items={.money=2147483647, .bag="[0,0,0,0]"},
         }
     );
     CHECK_CHARACTER(chr, want);

--- a/update_character.cpp
+++ b/update_character.cpp
@@ -128,4 +128,43 @@ void ClearMonsterKills(CCharacter& chr) {
     }
 }
 
+void TreasureOnNightmare(CCharacter& chr, bool coinflip) {
+    uint8_t add_body_min = 0;
+    uint8_t add_body_max = 1;
+
+    // Witch and amazon increase Body a bit faster as they start from 1 and 25.
+    if (chr.Sex == 192 || chr.Sex == 128) {
+        if (chr.Body < 15) {
+            add_body_min = 1; // At low body levels, at least +1 is guaranteed.
+            add_body_max = 4;
+        } else if (chr.Body < 25) {
+            add_body_min = 1;
+            add_body_max = 3;
+        } else if (chr.Body < 35) {
+            add_body_min = 1;
+            add_body_max = 2;
+        } else if (chr.Body < 45) {
+            add_body_max = 2;
+        }
+    }
+
+    chr.Body += coinflip ? add_body_min : add_body_max;
+}
+
+bool IncreaseUpTo(uint8_t* value, uint8_t increment, uint8_t limit) {
+    if (*value >= limit) {
+        // Already over the limit, leave as is.
+        return false;
+    }
+
+    *value += increment;
+
+    if (*value >= limit) {
+        // Can get only up to the limit, not more.
+        *value = limit;
+    }
+
+    return true;
+}
+
 } // namespace update_character

--- a/update_character.h
+++ b/update_character.h
@@ -15,4 +15,9 @@ bool HasKillsForReborn(CCharacter& chr, ServerIDType server_id);
 // Reset monster kills for reborn restriction
 void ClearMonsterKills(CCharacter& chr);
 
+void TreasureOnNightmare(CCharacter& chr, bool coinflip);
+
+// At QUEST_T1--QUEST_T3 a character can increase stats up to 70.
+bool IncreaseUpTo(uint8_t* value, uint8_t increment, uint8_t limit);
+
 } // namespace update_character


### PR DESCRIPTION
1. Amazons and witches get at least 1 guaranteed body per treasure on nightmare when their body stat is low. The average stays the same.
2. On QUEST_T1--QUEST_T3 respective stats can be increased up to 70.
3. Getting all three treasures on QUEST_T2 and QUEST_T3 gives 1 bonus stat.
4. Only on QUEST_T4 stats can be increased to 76.
5. Stats progression on QUEST_T4: mind -> spirit -> reaction.